### PR TITLE
Add configurable response headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 go:
-  - '1.12.6'
+  - '1.13'
 
 env:
   - GO111MODULE=on

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG APP_NAME=stubby
 ARG MAIN_PATH=cmd/main.go
 
 # -- Builder Image
-FROM golang:1.12.6-stretch As Builder
+FROM golang:1.13-stretch As Builder
 
 ARG ORG_NAME
 ARG REPO_NAME
@@ -23,7 +23,7 @@ WORKDIR /go/src/github.com/${ORG_NAME}/${REPO_NAME}
 # Set up dependencies
  COPY ./go.mod go.mod
  COPY ./go.sum go.sum
- RUN go mod vendor
+ RUN go mod download
 
 # Copy rest of the package code
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ all: help
 USERNAME = davyj0nes
 APP_NAME = stubby
 
-APP_PORT = 8080
-LOCAL_PORT = 8080
-
 VERSION = $(shell git describe --exact-match --tags 2>/dev/null)
 COMMIT = $(shell git rev-parse HEAD | cut -c 1-6)
 BUILD_TIME = $(shell date -u '+%Y-%m-%d_%I:%M:%S%p')
+
+APP_PORT = 8080
+LOCAL_PORT = 8080
 
 BUILD_PREFIX = CGO_ENABLED=0 GOOS=linux
 BUILD_FLAGS = -a -tags netgo --installsuffix netgo
@@ -49,7 +49,7 @@ publish:
 .PHONY: run_image
 run_image:
 	$(call blue, "# Running Docker Image Locally...")
-	@docker run -it --rm --name ${APP_NAME} -v ${PWD}/config.yaml:/config.yaml -p ${LOCAL_PORT}:${APP_PORT} ${USERNAME}/${APP_NAME}:${VERSION}
+	@docker run -it --rm --name ${APP_NAME} -v ${PWD}/config.yaml:/config.yaml -p ${LOCAL_PORT}:${APP_PORT} ${USERNAME}/${APP_NAME}
 
 ## test: run test suites
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Return stubbed HTTP responses defined in a config file
 
 ### Configuration
 
+### Basic
+
 Add the routes and the responses that you want in the [config file](./comfig.yaml).
 
 A basic route definition would look like:
@@ -36,6 +38,8 @@ routes:
         "message": "foo"
       }
 ```
+
+### URL Query Params
 
 If the response has URL parameters then these need to be defined as follows:
 
@@ -56,6 +60,24 @@ routes:
 The reason for having them defined in a list rather than as a key/value pair
 is due to how the (Queries](https://www.gorillatoolkit.org/pkg/mux#Route.Queries)
 method is defined in the router package used ([gorilla mux](https://www.gorillatoolkit.org)).
+
+### Custom Response Headers
+
+If you want the response to include a header then you can add it as such:
+
+```yaml
+routes:
+  - path: /foo
+    status: 200
+    headers:
+      X-Custom: Header
+      X-Request-Id: ef835eaf-a658-458b-86ae-d2d771f5e745
+    respose: >-
+      {
+        "id": 987,
+        "message": "bar"
+      }
+```
 
 ### Docker
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/davyj0nes/stubby/config"
 	"github.com/davyj0nes/stubby/router"
@@ -22,6 +27,33 @@ func main() {
 	r := router.NewRouter(cfg.Routes)
 	addr := fmt.Sprintf(":%d", cfg.Port)
 
-	log.Println("starting server on ", addr)
-	log.Fatal(http.ListenAndServe(addr, r))
+	srv := http.Server{
+		Addr:         addr,
+		Handler:      r,
+		ReadTimeout:  1 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+
+	log.Println("starting stubby on ", addr)
+	go func() {
+		log.Fatal(srv.ListenAndServe())
+
+	}()
+
+	log.Print("stubby is ready to serve...")
+
+	killSignal := <-interrupt
+	switch killSignal {
+	case os.Interrupt:
+		log.Println("got SIGINT...")
+		log.Println("stubby is shutting down...")
+	case syscall.SIGTERM:
+		log.Println("got SIGTERM...")
+		log.Println("stubby is shutting down...")
+	}
+
+	log.Fatal(srv.Shutdown(context.Background()))
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-port: 8888
+port: 8080
 routes:
   - path: /foo
     status: 200
@@ -13,7 +13,7 @@ routes:
       - show_deleted
       - true
     status: 200
-    respose: >-
+    response: >-
       {
         "id": 987,
         "message": "bar"
@@ -23,4 +23,14 @@ routes:
     response: >-
       {
         "message": "unauthorized"
+      }
+  - path: /withResponseHeaders
+    headers:
+      X-Request-Id: ef835eaf-a658-458b-86ae-d2d771f5e745
+      CustomHeader: booyah
+    status: 200
+    response: >-
+      {
+        "id": 123,
+        "message": "booyah"
       }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/davyj0nes/stubby
 
-go 1.12
+go 1.13
 
 require (
-	github.com/gorilla/mux v1.7.2
-	github.com/spf13/viper v1.4.0
+	github.com/gorilla/mux v1.7.3
+	github.com/spf13/viper v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
-github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -53,8 +53,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
-github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
+github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -86,11 +86,13 @@ github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
-github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spf13/viper v1.5.0 h1:GpsTwfsQ27oS/Aha/6d1oD7tpKIqWnOA6tgOX9HHkt4=
+github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
+github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -136,6 +138,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/route.go
+++ b/route.go
@@ -5,5 +5,6 @@ type Route struct {
 	Path     string
 	Response string
 	Status   int
+	Headers  map[string]string
 	Queries  []string
 }


### PR DESCRIPTION
A feature request was made to allow for custom HTTP headers to be returned from
the server per route.

This adds a new configuration option that is a map of header keys and
values. These are then mapped to the response as required.

Also made some improvements to the HTTP server, configuration and docs

> Satisfies #11 